### PR TITLE
Fix URL encoding in search endpoint and correct README paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,9 +74,9 @@ A brief overview of important files and directories:
 
 ## Available Endpoints
 This example application exposes the following API endpoints:
-- `POST /register`: Allows new users to register. Requires `name`, `email`, and `password` in the request body.
-- `POST /login`: Allows existing users to log in. Requires `email` and `password` in the request body. Returns a session token.
-- `GET /search`: An example protected endpoint that requires a valid Bearer token (obtained from login) in the `Authorization` header. It searches GitHub repositories based on a query parameter `q`.
+- `POST /api/auth/register`: Allows new users to register. Requires `name`, `email`, and `password` in the request body.
+- `POST /api/auth/login`: Allows existing users to log in. Requires `email` and `password` in the request body. Returns a session token.
+- `GET /api/search`: An example protected endpoint that requires a valid Bearer token (obtained from login) in the `Authorization` header. It searches GitHub repositories based on a query parameter `q`.
 
 The authentication logic (registration, login, and token validation) is detailed in the 'Authentication Flow' diagram below.
 

--- a/src/endpoints/search.ts
+++ b/src/endpoints/search.ts
@@ -41,7 +41,7 @@ export class GetSearch extends OpenAPIRoute {
         // Validate inputs
         const data = await this.getValidatedData<typeof this.schema>()
 
-        const resp = await fetch(`https://api.github.com/search/repositories?q=${data.query.q}`, {
+        const resp = await fetch(`https://api.github.com/search/repositories?q=${encodeURIComponent(data.query.q as string)}`, {
             headers: {
                 Accept: "application/vnd.github.v3+json",
                 "User-Agent": "RepoAI - Cloudflare Workers ChatGPT Plugin Example",

--- a/src/foundation/auth.ts
+++ b/src/foundation/auth.ts
@@ -175,7 +175,7 @@ export class AuthLogin extends OpenAPIRoute {
             },
         }).execute()
 
-        // User not found, provably wrong password
+        // User not found, probably wrong password
         if (!user.results) {
             return Response.json({
                 success: false,


### PR DESCRIPTION
## Summary

- **Bug fix**: URL-encode the `q` query parameter in the GitHub API search request (`src/endpoints/search.ts`). Without encoding, queries containing special characters (spaces, `&`, `#`, etc.) could produce malformed URLs or unexpected API results.
- **Documentation fix**: Correct the endpoint paths listed in the README's "Available Endpoints" section — they were missing the `/api/auth/` and `/api/` prefixes (e.g., `/register` → `/api/auth/register`).
- **Typo fix**: Fix "provably" → "probably" in an auth comment.

## Test plan

- [x] All 11 existing tests pass (`npm test`)
- [x] Changes are minimal and focused (5 lines changed across 3 files)
- [x] No breaking changes — `encodeURIComponent` is transparent for simple alphanumeric queries

🤖 Generated with [Claude Code](https://claude.com/claude-code)