### PR TITLE
Use crypto.randomUUID() for session token generation

### DIFF
--- a/src/foundation/auth.ts
+++ b/src/foundation/auth.ts
@@ -194,7 +194,7 @@ export class AuthLogin extends OpenAPIRoute {
             tableName: 'users_sessions',
             data: {
                 user_id: user.results.id,
-                token: await hashPassword((Math.random() + 1).toString(3), c.env.SALT_TOKEN),
+                token: await hashPassword(crypto.randomUUID(), c.env.SALT_TOKEN),
                 expires_at: expiration.getTime()
             },
             returning: '*'


### PR DESCRIPTION
## Summary

Replace `Math.random()` with `crypto.randomUUID()` for generating session tokens in the login endpoint.

`Math.random()` is not cryptographically secure — its output can be predictable, which is a concern for session token generation. `crypto.randomUUID()` uses the platform's cryptographic random number generator and is available in Cloudflare Workers, making it the appropriate choice for security-sensitive randomness.

Since this is an example project that developers reference when building authentication systems, it's important to demonstrate secure practices.

## Changes

- `src/foundation/auth.ts`: Replace `(Math.random() + 1).toString(3)` with `crypto.randomUUID()` as the input to the token hash function

## Test plan

- [x] All 11 existing tests pass (`npm test`)
- [x] No breaking changes — the token format (SHA-256 hex hash) remains the same
- [x] `crypto.randomUUID()` is available in Cloudflare Workers runtime